### PR TITLE
feat: 채팅방 리스트 조회 api 구현

### DIFF
--- a/campton/campton/src/main/java/com/dongguk/campton/controller/RoomController.java
+++ b/campton/campton/src/main/java/com/dongguk/campton/controller/RoomController.java
@@ -1,13 +1,29 @@
 package com.dongguk.campton.controller;
 
+import com.dongguk.campton.dto.request.MemberIdRequestDto;
+import com.dongguk.campton.dto.response.RoomResponseDto;
+import com.dongguk.campton.dto.response.ResponseDto;
 import com.dongguk.campton.service.RoomService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/room")
 public class RoomController {
     private final RoomService roomService;
+
+
+    @GetMapping("/list")
+    public ResponseDto<List<RoomResponseDto>> getChattingList(
+            @Valid @RequestBody MemberIdRequestDto memberIdRequestDto){
+        return new ResponseDto<>(roomService.getList(memberIdRequestDto));
+
+    }
 }

--- a/campton/campton/src/main/java/com/dongguk/campton/dto/response/RoomResponseDto.java
+++ b/campton/campton/src/main/java/com/dongguk/campton/dto/response/RoomResponseDto.java
@@ -1,0 +1,21 @@
+package com.dongguk.campton.dto.response;
+
+import com.dongguk.campton.domain.Member;
+import com.dongguk.campton.domain.Room;
+import com.dongguk.campton.domain.enums.RoomType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RoomResponseDto {
+
+    private Long room_id;
+
+    private RoomType room_type;
+
+}

--- a/campton/campton/src/main/java/com/dongguk/campton/respository/RoomRepository.java
+++ b/campton/campton/src/main/java/com/dongguk/campton/respository/RoomRepository.java
@@ -1,10 +1,14 @@
 package com.dongguk.campton.respository;
 
+import com.dongguk.campton.domain.Member;
 import com.dongguk.campton.domain.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
+    List<Room> findAllByMemberId(Long memberId);
 }

--- a/campton/campton/src/main/java/com/dongguk/campton/service/RoomService.java
+++ b/campton/campton/src/main/java/com/dongguk/campton/service/RoomService.java
@@ -1,13 +1,33 @@
 package com.dongguk.campton.service;
 
+import com.dongguk.campton.domain.Room;
+import com.dongguk.campton.dto.request.MemberIdRequestDto;
+import com.dongguk.campton.dto.response.RoomResponseDto;
+import com.dongguk.campton.exception.ApiException;
 import com.dongguk.campton.respository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class RoomService {
     private final RoomRepository roomRepository;
+
+
+    public List<RoomResponseDto> getList(MemberIdRequestDto memberIdRequestDto) {
+
+        List<Room> rooms = roomRepository.findAllByMemberId(memberIdRequestDto.getMemberId());
+
+        return rooms.stream()
+                .map(room -> RoomResponseDto.builder()
+                        .room_id(room.getId())
+                        .room_type(room.getRoomType())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- Resolves : 회원 정보를 기반으로 회원의 채팅방을 조회하는 API
 
## 작업 사항
- 채팅방 리스트  조회
- 채팅방 정보에는 채팅방의 id, type정보가 포함된다.